### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/LAB_01_virtual_networks.md
+++ b/Instructions/Labs/LAB_01_virtual_networks.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Exercise 01: Create and configure virtual networks'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 01: Create and configure virtual networks'
+  module: Guided Project - Configure secure access to workloads with Azure virtual
+    networking services
+  description: Your organization is migrating a web-based application to Azure. Your
+    first task is to put in place the virtual networks and subnets. You also need
+    to securely peer the virtual networks. You identify these requirements.
+  duration: 20 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # Exercise 01: Create and configure virtual networks

--- a/Instructions/Labs/LAB_02_security_groups.md
+++ b/Instructions/Labs/LAB_02_security_groups.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Exercise 02: Create and configure network security groups'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 02: Create and configure network security groups'
+  module: Guided Project - Configure secure access to workloads with Azure virtual
+    networking services
+  description: Your organization requires the network traffic in the app-vnet to be
+    tightly controlled. You identify these requirements.
+  duration: 25 minutes
+  level: 400
+  islab: true
 ---
 
 # Exercise 02: Create and configure network security groups

--- a/Instructions/Labs/LAB_03_firewall.md
+++ b/Instructions/Labs/LAB_03_firewall.md
@@ -1,7 +1,20 @@
 ---
 lab:
-    title: 'Exercise 03: Create and configure Azure Firewall'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 03: Create and configure Azure Firewall'
+  module: Guided Project - Configure secure access to workloads with Azure virtual
+    networking services
+  description: Your organization requires centralized network security for the application
+    virtual network. As the application usage increases, more granular application-level
+    filtering and advanced threat protection will be needed. Also, it is expected
+    the application will need continuous updates from Azure DevOps pipelines. You
+    identify these requirements.
+  duration: 25 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure DevOps
+  - Azure Firewall
 ---
 
 # Exercise 03: Create and configure Azure Firewall

--- a/Instructions/Labs/LAB_04_route.md
+++ b/Instructions/Labs/LAB_04_route.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Exercise 04: Configure network routing'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 04: Configure network routing'
+  module: Guided Project - Configure secure access to workloads with Azure virtual
+    networking services
+  description: To ensure the firewall policies are enforced, outbound application
+    traffic must be routed through the firewall. You identify these requirements.
+  duration: 20 minutes
+  level: 400
+  islab: true
 ---
 
 # Exercise 04: Configure network routing

--- a/Instructions/Labs/LAB_05_domain_name.md
+++ b/Instructions/Labs/LAB_05_domain_name.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Exercise 05: Create DNS zones and configure DNS settings'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 05: Create DNS zones and configure DNS settings'
+  module: Guided Project - Configure secure access to workloads with Azure virtual
+    networking services
+  description: Your organization requires workloads to use domain names instead of
+    IP addresses for internal communications.  The organization doesn’t want to add
+    a custom DNS solution. You identify these requirements.
+  duration: 20 minutes
+  level: 300
+  islab: true
 ---
 
 # Exercise 05: Create DNS zones and configure DNS settings


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/LAB_01_virtual_networks.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_02_security_groups.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_03_firewall.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_04_route.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_05_domain_name.md` (description,duration,level,islab)
