### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/LAB_01_virtual_networks.md
+++ b/Instructions/Labs/LAB_01_virtual_networks.md
@@ -2,9 +2,9 @@
 lab:
   title: 'Exercise 01: Create and configure virtual networks'
   module: Guided Project - Configure secure access to workloads with Azure virtual networking services
-  description: An Azure virtual network enables many types of Azure resources to securely communicate with each other, the internet, and on-premises networks. All Azure resources in a virtual network are deployed into subnets within the virtual network.
+  description: Create and configure virtual networks, subnets, and peering. 
   duration: 20 minutes
-  level: 400
+  level: 300
   islab: true
   primarytopics:
     - Azure

--- a/Instructions/Labs/LAB_01_virtual_networks.md
+++ b/Instructions/Labs/LAB_01_virtual_networks.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Exercise 01: Create and configure virtual networks'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 01: Create and configure virtual networks'
+  module: Guided Project - Configure secure access to workloads with Azure virtual networking services
+  description: An Azure virtual network enables many types of Azure resources to securely communicate with each other, the internet, and on-premises networks. All Azure resources in a virtual network are deployed into subnets within the virtual network.
+  duration: 20 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Virtual Network
 ---
 
 # Exercise 01: Create and configure virtual networks

--- a/Instructions/Labs/LAB_02_security_groups.md
+++ b/Instructions/Labs/LAB_02_security_groups.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Exercise 02: Create and configure network security groups'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 02: Create and configure network security groups'
+  module: Guided Project - Configure secure access to workloads with Azure virtual networking services
+  description: An NSG use security rules to filter inbound and outbound network traffic.
+  duration: 25 minutes
+  level: 400
+  islab: true
 ---
 
 # Exercise 02: Create and configure network security groups

--- a/Instructions/Labs/LAB_02_security_groups.md
+++ b/Instructions/Labs/LAB_02_security_groups.md
@@ -2,10 +2,14 @@
 lab:
   title: 'Exercise 02: Create and configure network security groups'
   module: Guided Project - Configure secure access to workloads with Azure virtual networking services
-  description: An NSG use security rules to filter inbound and outbound network traffic.
+  description: Create and confgure network and application security groups. 
   duration: 25 minutes
-  level: 400
+  level: 300
   islab: true
+  primarytopics:
+  - Azure
+  - Network security groups
+  - Application security groups
 ---
 
 # Exercise 02: Create and configure network security groups

--- a/Instructions/Labs/LAB_03_firewall.md
+++ b/Instructions/Labs/LAB_03_firewall.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Exercise 03: Create and configure Azure Firewall'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 03: Create and configure Azure Firewall'
+  module: Guided Project - Configure secure access to workloads with Azure virtual networking services
+  description: Your organization requires centralized network security for the application virtual network. As the application usage increases, more granular application-level filtering and advanced threat protection will be needed. Also, it is expected the application will need continuous updates from Azure DevOps pipelines. You identify these requirements.
+  duration: 25 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure DevOps
+    - Azure Firewall
 ---
 
 # Exercise 03: Create and configure Azure Firewall

--- a/Instructions/Labs/LAB_03_firewall.md
+++ b/Instructions/Labs/LAB_03_firewall.md
@@ -2,13 +2,12 @@
 lab:
   title: 'Exercise 03: Create and configure Azure Firewall'
   module: Guided Project - Configure secure access to workloads with Azure virtual networking services
-  description: Your organization requires centralized network security for the application virtual network. As the application usage increases, more granular application-level filtering and advanced threat protection will be needed. Also, it is expected the application will need continuous updates from Azure DevOps pipelines. You identify these requirements.
+  description: Create and configure Azure Firewall. 
   duration: 25 minutes
-  level: 500
+  level: 300
   islab: true
   primarytopics:
     - Azure
-    - Azure DevOps
     - Azure Firewall
 ---
 

--- a/Instructions/Labs/LAB_04_route.md
+++ b/Instructions/Labs/LAB_04_route.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Exercise 04: Configure network routing'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 04: Configure network routing'
+  module: Guided Project - Configure secure access to workloads with Azure virtual networking services
+  description: Azure automatically creates a route table for each subnet within an Azure virtual network. The route table includes the default system routes. You can create route tables and routes to override Azure's default system routes.
+  duration: 20 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Virtual Network
 ---
 
 # Exercise 04: Configure network routing

--- a/Instructions/Labs/LAB_04_route.md
+++ b/Instructions/Labs/LAB_04_route.md
@@ -2,13 +2,14 @@
 lab:
   title: 'Exercise 04: Configure network routing'
   module: Guided Project - Configure secure access to workloads with Azure virtual networking services
-  description: Azure automatically creates a route table for each subnet within an Azure virtual network. The route table includes the default system routes. You can create route tables and routes to override Azure's default system routes.
+  description: Create and configure routing tables. 
   duration: 20 minutes
-  level: 400
+  level: 300
   islab: true
   primarytopics:
     - Azure
     - Azure Virtual Network
+    - Network routing
 ---
 
 # Exercise 04: Configure network routing

--- a/Instructions/Labs/LAB_05_domain_name.md
+++ b/Instructions/Labs/LAB_05_domain_name.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Exercise 05: Create DNS zones and configure DNS settings'
-    module: 'Guided Project - Configure secure access to workloads with Azure virtual networking services'
+  title: 'Exercise 05: Create DNS zones and configure DNS settings'
+  module: Guided Project - Configure secure access to workloads with Azure virtual networking services
+  description: Azure Private DNS provides a reliable, secure DNS service to manage and resolve domain names in a virtual network without the need to add a custom DNS solution. By using private DNS zones, you can use your own custom domain names rather than the Azure-provided names.
+  duration: 20 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Exercise 05: Create DNS zones and configure DNS settings

--- a/Instructions/Labs/LAB_05_domain_name.md
+++ b/Instructions/Labs/LAB_05_domain_name.md
@@ -2,12 +2,13 @@
 lab:
   title: 'Exercise 05: Create DNS zones and configure DNS settings'
   module: Guided Project - Configure secure access to workloads with Azure virtual networking services
-  description: Azure Private DNS provides a reliable, secure DNS service to manage and resolve domain names in a virtual network without the need to add a custom DNS solution. By using private DNS zones, you can use your own custom domain names rather than the Azure-provided names.
+  description: Create and configure Azure DNS zones. 
   duration: 20 minutes
   level: 300
   islab: true
   primarytopics:
     - Azure
+    - Azure DNS 
 ---
 
 # Exercise 05: Create DNS zones and configure DNS settings


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/LAB_01_virtual_networks.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_02_security_groups.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_03_firewall.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_04_route.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_05_domain_name.md` (description,duration,level,islab,primarytopics)
